### PR TITLE
Moved all but one sql statement into postgres abstraction class

### DIFF
--- a/DB/DBInterface.h
+++ b/DB/DBInterface.h
@@ -20,6 +20,13 @@ If not, see <https://www.gnu.org/licenses/>.
 
 #include "soci.h"
 
+using soci::session;
+using soci::row;
+using soci::rowset;
+using soci::statement;
+using soci::use;
+using soci::into;
+
 class DBInterface {
 public:
   virtual ~DBInterface();
@@ -28,11 +35,20 @@ public:
   virtual void clear() = 0;
   soci::session getSociSession();
 
+  virtual int createUser( std::string uname, std::string password, int admin ) = 0;
+  virtual int createChannel(std::string name, int community, int admin_id, int anonymous) = 0;
+  virtual int createCommunity(std::string name, int admin, int pub) = 0;
+  virtual rowset<row> getCommunityRowset(soci::session &sql) = 0;
+  virtual rowset<row> getCommunityChannelsRowset(soci::session &sql, int community_id) = 0;
+  virtual rowset<row> getChannelMessages(soci::session &sql, int channel_id) = 0;
+  virtual std::unique_ptr<row> getChannelRow(soci::session &sql, int channel_id) = 0;
+
 protected:
   DBInterface( const soci::backend_factory &backend, std::string conString );
 
   const soci::backend_factory &dbType_;
   std::string dbConnectString_;
+
 };
 
 #endif // DB_INTERFACE_H

--- a/DB/DBPostgres.h
+++ b/DB/DBPostgres.h
@@ -27,6 +27,14 @@ public:
   ~DBPostgres();
   virtual void validate() override;
   virtual void clear() override;
+
+  virtual int createUser(std::string uname, std::string password, int admin) override;
+  virtual int createChannel(std::string name, int community, int admin_id, int anonymous) override;
+  virtual int createCommunity(std::string name, int admin, int pub) override;
+  virtual rowset<row> getCommunityRowset(soci::session &sql) override;
+  virtual rowset<row> getCommunityChannelsRowset(soci::session &sql, int community_id) override;
+  virtual rowset<row> getChannelMessages(soci::session &sql, int channel_id) override;
+  virtual std::unique_ptr<row> getChannelRow(soci::session &sql, int channel_id) override;
 };
 
 #endif // DB_POSTGRES_H


### PR DESCRIPTION
Every SQL statement in the implementation class has now been moved into the postgres abstraction class, aside from the statement in `SendWrongthinkMessageImp` which I wasn't sure what to do with because it's highly coupled to the logic around it (executed multiple times with different local variables). 